### PR TITLE
add proper library commentary

### DIFF
--- a/package-filter.el
+++ b/package-filter.el
@@ -1,30 +1,24 @@
-;;; package-filter.el --- special handling for package.el
-;;
+;;; package-filter.el --- package archive whitelist and blacklist
+
 ;; Copyright 2012-2014 Donald Ephraim Curtis
 ;; Copyright 2012-2014 Steve Purcell
 ;;
 ;; Author: Donald Ephraim Curtis <dcurtis@milkbox.net>
 ;; URL: https://github.com/milkypostman/package-filter
 ;; Version: 0.3
-;;
-;;
-;; Credits:
-;;   Steve Purcell
-;;
-;;
-;; Installation:
-;;
-;; (progn
-;;   (switch-to-buffer
-;;    (url-retrieve-synchronously
-;;     "https://raw.github.com/milkypostman/package-filter/master/package-filter.el"))
-;;   (package-install-from-buffer  (package-buffer-info) 'single))
-;;
-;;
-;;
-;; Code goes here
-;;
 
+;;; Commentary:
+
+;; **** Obsolete since Emacs 24.4: Users should customize or otherwise
+;; **** modify the new `package-pinned-packages` variable instead.
+
+;; This package adds functionality to `package.el` to allow creating
+;; a whitelist or blacklist of packages for a specific repository.
+;; This allows for disabling all packages from a specific repository
+;; and only enabling certain packages, or simply blacklist a certain
+;; subset of packages.
+
+;;; Code:
 
 ;;;###autoload
 (defcustom package-archive-enable-alist nil


### PR DESCRIPTION
This makes it less likely that a user of a more
recent Emacs release installs this by mistake.
